### PR TITLE
Graphs d'Occupations

### DIFF
--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -189,13 +189,19 @@ class NetworkController extends Controller
         }
 
         // color the adresses reserved by the network with its color
-        //$color = networkColor($network) //FIXME use color of the network to define a color with rgb values in a imagecolorallocate
-        $color = imagecolorallocate($image, 255, 0, 0);// pure red for all networks for now
+        $color = imagecolorallocate($image,
+                                    $network->getRed(),
+                                    $network->getGreen(),
+                                    $network->getBlue());
+
+        $red = imagecolorallocate($image, 255, 0, 0);
+
         $ips = $network->getIps();
-        $adressIndex = 0;
+        $plages = $network->getPlages();
+
         // the first line will be initialized at 0 in the loops by adding 1
         $line = -1;
-
+        $adressIndex = 0;
         for( $i = 0; $i < $height; $i++ )
         {
           for( $j = 0; $j < $width; $j++ )
@@ -208,6 +214,7 @@ class NetworkController extends Controller
                 {
                     $line += 1;
                 }
+
                $adress = $network->getIp() + ($adressIndex %($width/$adressWidth))+($line*($width/$adressWidth));
                foreach ($ips as $ip)
                {
@@ -216,7 +223,28 @@ class NetworkController extends Controller
                        $setColor = true;
                        imagesetpixel($image, $j, $i, $color);
                    }
+               }/*
+
+               if ($inPlage)
+               {
+                   if ($plages->getEnd() == $adress)
+                   {
+                       $inPlage = false;
+                   }
+                   $setColor = true;
                }
+               else
+               {
+                   foreach ($plages as $plage)
+                   {
+                       if ($plage->getStart() == $adress)
+                       {
+                           $setColor = true;
+                           $inPlage = true;
+                           imagesetpixel($image, $j, $i, $color);
+                       }
+                   }
+               }*/
             }
             if ( $setColor )
             {

--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -187,22 +187,26 @@ class NetworkController extends Controller
                                     $network->getGreen(),
                                     $network->getBlue());
 
-        $red = imagecolorallocate($image, 255, 0, 0);
-        $green=imagecolorallocate($image, 0,255, 0);
         $ips = $network->getIps();
         $plages = $network->getPlages();
 
         // the first line will be initialized at 0 in the loops by adding 1
         $line = -1;
         $adressIndex = 0;
-        $inPlage = false;
+
+        // default value of $startPlage and $endPlage are not in the network
+        $startPlage = $network->getIp()+ 2**(32 - $cidr);
+        $endPlage = $network->getIp()+ + 2**(32 - $cidr);
+
         for( $i = 0; $i < $height; $i++ )
         {
           for( $j = 0; $j < $width; $j++ )
           {
-            if ( $j % $adressWidth == 0 )
+
+            if ($j % $adressWidth == 0 )
             {
-                if ($i % $adressHeight == 0 && $j == 0 )
+
+                if ( $i % $adressHeight == 0 && $j == 0 )
                 {
                     $line += 1;
                 }
@@ -210,6 +214,7 @@ class NetworkController extends Controller
                 $setColor = false;
                 $adressIndex += 1;
 
+                // if $adressIndex % ($width/$adressWidth) == 0 then the adress is exactly ($width/$adressWidth) plus the line
                 if($adressIndex % ($width/$adressWidth) == 0)
                 {
                     $adress = $network->getIp() + ($width/$adressWidth)+($line*($width/$adressWidth));
@@ -219,14 +224,9 @@ class NetworkController extends Controller
                     $adress = $network->getIp() + ($adressIndex %($width/$adressWidth))+($line*($width/$adressWidth));
                 }
 
-               if ($inPlage)
+               if ($adress >= $startPlage && $adress <= $endPlage)
                {
                    $setColor = true;
-                   if ($endPlage == $adress-1)
-                   {
-                       $inPlage = false;
-                       $setColor = false;
-                   }
                }
                else
                {
@@ -235,8 +235,9 @@ class NetworkController extends Controller
                        if ($plage->getStart() == $adress)
                        {
                            $setColor = true;
-                           $inPlage = true;
+                           $startPlage = $plage->getStart();
                            $endPlage = $plage->getEnd();
+                           // the color used is the plage's color not the network's  color
                            $plageColor = imagecolorallocate($image,
                                                        $plage->getRed(),
                                                        $plage->getGreen(),
@@ -252,14 +253,13 @@ class NetworkController extends Controller
                        $setColor = true;
                    }
                }
-            }
+           }
 
             if ( $setColor )
             {
-                if ($inPlage)
+                if ($adress >= $startPlage && $adress <= $endPlage)
                 {
                     imagesetpixel($image, $j, $i, $plageColor);
-
                 }
                 else
                 {

--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -219,18 +219,14 @@ class NetworkController extends Controller
                     $adress = $network->getIp() + ($adressIndex %($width/$adressWidth))+($line*($width/$adressWidth));
                 }
 
-
-               foreach ($ips as $ip)
-               {
-                   if ($ip->getIp() == $adress)
-                   {
-                       $setColor = true;
-                   }
-               }
-
                if ($inPlage)
                {
                    $setColor = true;
+                   if ($endPlage == $adress-1)
+                   {
+                       $inPlage = false;
+                       $setColor = false;
+                   }
                }
                else
                {
@@ -248,16 +244,22 @@ class NetworkController extends Controller
                        }
                    }
                }
+
+               foreach ($ips as $ip)
+               {
+                   if ($ip->getIp() == $adress)
+                   {
+                       $setColor = true;
+                   }
+               }
             }
+
             if ( $setColor )
             {
                 if ($inPlage)
                 {
                     imagesetpixel($image, $j, $i, $plageColor);
-                    if ($endPlage == $adress)
-                    {
-                        $inPlage = false;
-                    }
+
                 }
                 else
                 {

--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -202,6 +202,7 @@ class NetworkController extends Controller
         // the first line will be initialized at 0 in the loops by adding 1
         $line = -1;
         $adressIndex = 0;
+        $inPlage = false;
         for( $i = 0; $i < $height; $i++ )
         {
           for( $j = 0; $j < $width; $j++ )
@@ -221,13 +222,12 @@ class NetworkController extends Controller
                    if ($ip->getIp() == $adress)
                    {
                        $setColor = true;
-                       imagesetpixel($image, $j, $i, $color);
                    }
-               }/*
+               }
 
                if ($inPlage)
                {
-                   if ($plages->getEnd() == $adress)
+                   if ($endPlage == $adress)
                    {
                        $inPlage = false;
                    }
@@ -241,12 +241,13 @@ class NetworkController extends Controller
                        {
                            $setColor = true;
                            $inPlage = true;
+                           $endPlage = $plage->getEnd();
                            imagesetpixel($image, $j, $i, $color);
                        }
                    }
-               }*/
+               }
             }
-            if ( $setColor )
+            if ( $setColor ) //&& (($j % $adressWidth) != 0))
             {
                 imagesetpixel($image, $j, $i, $color);
             }

--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -143,13 +143,6 @@ class NetworkController extends Controller
         return $this->render('@App/default/network/show.html.twig', $view);
     }
 
-    private function getAdressSize(Network $network)
-    {
-    }
-
-    private function isReserved(Network $network, int $adressIndex)
-    {
-    }
     /**
      * Generates the occupation graph for a network entity.
      *
@@ -195,7 +188,7 @@ class NetworkController extends Controller
                                     $network->getBlue());
 
         $red = imagecolorallocate($image, 255, 0, 0);
-
+        $green=imagecolorallocate($image, 0,255, 0);
         $ips = $network->getIps();
         $plages = $network->getPlages();
 
@@ -209,14 +202,24 @@ class NetworkController extends Controller
           {
             if ( $j % $adressWidth == 0 )
             {
-                $setColor = false;
-                $adressIndex += 1;
                 if ($i % $adressHeight == 0 && $j == 0 )
                 {
                     $line += 1;
                 }
 
-               $adress = $network->getIp() + ($adressIndex %($width/$adressWidth))+($line*($width/$adressWidth));
+                $setColor = false;
+                $adressIndex += 1;
+
+                if($adressIndex % ($width/$adressWidth) == 0)
+                {
+                    $adress = $network->getIp() + ($width/$adressWidth)+($line*($width/$adressWidth));
+                }
+                else
+                {
+                    $adress = $network->getIp() + ($adressIndex %($width/$adressWidth))+($line*($width/$adressWidth));
+                }
+
+
                foreach ($ips as $ip)
                {
                    if ($ip->getIp() == $adress)
@@ -227,10 +230,6 @@ class NetworkController extends Controller
 
                if ($inPlage)
                {
-                   if ($endPlage == $adress)
-                   {
-                       $inPlage = false;
-                   }
                    $setColor = true;
                }
                else
@@ -242,14 +241,28 @@ class NetworkController extends Controller
                            $setColor = true;
                            $inPlage = true;
                            $endPlage = $plage->getEnd();
-                           imagesetpixel($image, $j, $i, $color);
+                           $plageColor = imagecolorallocate($image,
+                                                       $plage->getRed(),
+                                                       $plage->getGreen(),
+                                                       $plage->getBlue());
                        }
                    }
                }
             }
-            if ( $setColor ) //&& (($j % $adressWidth) != 0))
+            if ( $setColor )
             {
-                imagesetpixel($image, $j, $i, $color);
+                if ($inPlage)
+                {
+                    imagesetpixel($image, $j, $i, $plageColor);
+                    if ($endPlage == $adress)
+                    {
+                        $inPlage = false;
+                    }
+                }
+                else
+                {
+                    imagesetpixel($image, $j, $i, $color);
+                }
             }
           }
       }

--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -195,8 +195,8 @@ class NetworkController extends Controller
         $adressIndex = 0;
 
         // default value of $startPlage and $endPlage are not in the network
-        $startPlage = $network->getIp()+ 2**(32 - $cidr);
-        $endPlage = $network->getIp()+ + 2**(32 - $cidr);
+        $startPlage = $network->getIp()+ 2**(32 - $cidr)+1;
+        $endPlage = $network->getIp()+ + 2**(32 - $cidr)+1;
 
         for( $i = 0; $i < $height; $i++ )
         {


### PR DESCRIPTION
Ce qui a été fait :+1: 
- adress ip  ou machine réservé ayant la couleur du réseau.
- plage d'adresse ayant leur couleur associé.
- adresses sur plusieurs lignes en fonction de la taille du réseaux
- possibilité d'obtenir une plage sur deux ligne

ce qui peut être amélioré:
- hauteur et largeur (en pixel) est fixe -> à faire varié en fonction du réseaux
- détail cosmétique peuvent être amélioré